### PR TITLE
Support variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ pip3 install nska_deserialize
 
 #### Usage
 
+##### From a file
+
 ```python
 import nska_deserialize as nd
 
@@ -39,4 +41,33 @@ with open(input_path, 'rb') as f:
 
         nd.write_plist_to_json_file(deserialized_plist, output_path_json)
         nd.write_plist_to_file(deserialized_plist, output_path_plist)
+```
+
+##### From a String
+
+```python
+import nska_deserialize as nd
+
+plist_in_string = "{notional string that might have come from a database}"
+
+try:
+    deserialized_plist = nd.deserialize_plist_from_string(plist_in_string)
+    print(deserialized_plist)
+except (nd.DeserializeError, 
+        nd.biplist.NotBinaryPlistException, 
+        nd.biplist.InvalidPlistException,
+        nd.ccl_bplist.BplistError, 
+        ValueError, 
+        TypeError, OSError, OverflowError) as ex:
+    # These are all possible errors from libraries imported
+
+    print('Had exception: ' + str(ex))
+    deserialized_plist = None
+
+if deserialized_plist:
+    output_path_plist = input_path + '_deserialized.plist'
+    output_path_json  = input_path + '_deserialized.json'
+
+    nd.write_plist_to_json_file(deserialized_plist, output_path_json)
+    nd.write_plist_to_file(deserialized_plist, output_path_plist)
 ```

--- a/nska_deserialize.py
+++ b/nska_deserialize.py
@@ -172,15 +172,12 @@ def _get_root_element_names(f):
 
     return roots
 
-def _get_valid_nska_plist(f, source):
+def _get_valid_nska_plist(f):
     '''Checks if there is an embedded NSKeyedArchiver plist as a data blob. On 
        ios, several files are like that. Also converts any xml based plist to 
        binary plist. Returns a file object representing a binary plist file.
     '''
     plist = ''
-    if source == 'variable':
-        f = io.BytesIO(f)
-
     plist = biplist.readPlist(f)
     if isinstance(plist, bytes):
         data = plist
@@ -266,7 +263,7 @@ def deserialize_plist(path_or_file):
     else: # its a file
         f = path_or_file
 
-    f = _get_valid_nska_plist(f, "file")
+    f = _get_valid_nska_plist(f)
     return _unpack_top_level(f)
 
 def deserialize_plist_from_string(bytes_to_deserialize):
@@ -293,7 +290,7 @@ def deserialize_plist_from_string(bytes_to_deserialize):
         OSError, 
         OverflowError
     '''
-    f = _get_valid_nska_plist(bytes_to_deserialize, "variable")
+    f = _get_valid_nska_plist(io.BytesIO(bytes_to_deserialize))
     return _unpack_top_level(f)
 
 def _get_json_writeable_plist(in_plist, out_plist):

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ req = [x.strip() for x in req if x.strip()]
 
 setuptools.setup(
     name="nska_deserialize",
-    version="1.0.0",
+    version="1.1.0",
     author="Yogesh Khatri",
     author_email="yogesh@swiftforensics.com",
     description="Convert NSKeyedArchiver plist into a deserialized human readable plist",


### PR DESCRIPTION
In order to allow for reading a binary plist directly from a variable already in memory, I added a new function _deserialize_plist_from_string which wraps the argument in io.BytesIO. While I now see this would be possible even with deserialize_plist, having an explicitly named function for this behavior matches what is expected in biplist (which has both readPlist and readPlistFromString) and makes it more accessible. 

In the below test, it is a lot quicker to tell what is going on in the first of the two database versions, even though they all end up evaluating to the same result.

```python
import io
import nska_deserialize as nd
import sqlite3

# Using an example from an Apple Notes database.
db = sqlite3.connect("./NoteStore.sqlite")
cursor = db.cursor()
cursor.execute("SELECT ZSERVERSHAREDATA FROM ZICCLOUDSYNCINGOBJECT WHERE Z_PK=147")
all_rows = cursor.fetchall()

# use the new function to just put the variable in
from_db1 = nd.deserialize_plist_from_string(all_rows[0][0])

# use the existing function, but wrap it in io.BytesIO
from_db2 = nd.deserialize_plist(io.BytesIO(all_rows[0][0]))

# use the existing function on the same data from the same cell, just exported from SQLiteBrowser
from_file = nd.deserialize_plist("./z_pk_147.bin")

print(from_db1 == from_db2 and from_db2 == from_file)    # => True
```
Appreciate your consideration of this pull request.

Fixes #1.